### PR TITLE
Added <Table.Row> due to compile errors in React dev

### DIFF
--- a/src/components/Table/TableHeader.examples.md
+++ b/src/components/Table/TableHeader.examples.md
@@ -1,9 +1,11 @@
 ```jsx
 <Table>
   <Table.Header>
-    <Table.ColHeader>ID</Table.ColHeader>
-    <Table.ColHeader>Name</Table.ColHeader>
-    <Table.ColHeader>Action</Table.ColHeader>
+    <Table.Row>
+      <Table.ColHeader>ID</Table.ColHeader>
+      <Table.ColHeader>Name</Table.ColHeader>
+      <Table.ColHeader>Action</Table.ColHeader>
+    </Table.Row>
   </Table.Header>
 </Table>
 ```


### PR DESCRIPTION
I was getting errors that <th> can't be child of <thead> - so it needs to have a <tr> added around the header columns to quiet the warnings.
